### PR TITLE
Enable passing an HTML link for a context menu <li> element

### DIFF
--- a/jquery.contextMenu.js
+++ b/jquery.contextMenu.js
@@ -35,7 +35,13 @@
     });
 
     $.each(actions, function(me, itemOptions) {
-      var menuItem = $('<li><a href="#">'+me+'</a></li>');
+      if (itemOptions.link) {
+        var link = itemOptions.link;  
+      } else {
+        var link = '<a href="#">'+me+'</a>';  
+      } 
+      
+      var menuItem = $('<li>' + link + '</li>');
 
       if (itemOptions.klass) {
         menuItem.attr("class", itemOptions.klass);


### PR DESCRIPTION
I added a few lines of code to allow you to pass an HTML link to be used for a <li> element. This way, you can either have a menu item trigger a callback function, or follow the HTML link.
